### PR TITLE
FIX - Set the graphql-ruby dependency to 1.9.18 pessimistically.

### DIFF
--- a/graphql-schema_comparator.gemspec
+++ b/graphql-schema_comparator.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["graphql-schema", "schema_comparator"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "graphql", "~> 1.6"
+  spec.add_dependency "graphql", "~> 1.9.18"
   spec.add_dependency "thor", ">= 0.19", "< 2.0"
   spec.add_dependency "bundler", ">= 1.14"
 


### PR DESCRIPTION
`graphql-ruby v1.10.0` was released with breaking changes. 

This has caused the comparator to incorrectly identify changes in schemas that are not there.

An issue has been created https://github.com/xuorig/graphql-schema_comparator/issues/28 to address it